### PR TITLE
Fix standard notes xml

### DIFF
--- a/xthursdayx/standardnotes-web.xml
+++ b/xthursdayx/standardnotes-web.xml
@@ -13,7 +13,7 @@
 &#xD;
 Standard Notes is a simple and private notes app available on most platforms, including Web, Mac, Windows, Linux, iOS, and Android.&#xD;
 &#xD;
-Before you start, make sure to copy the <a href="https://raw.githubusercontent.com/standardnotes/web/develop/.env.sample">sample .env.sample</a> to your standardnotes-web appdata directory and configure it with your parameters. Update the container ExtraParams accordingly.</Overview>
+Before you start, make sure to copy the sample.env.sample (https://raw.githubusercontent.com/standardnotes/web/develop/.env.sample) to your standardnotes-web appdata directory and configure it with your parameters. Update the container ExtraParams accordingly.</Overview>
   <Category>Productivity:</Category>
   <WebUI>http://[IP]:[3001]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/xthursdayx/docker-templates/master/xthursdayx/standardnotes-web.xml</TemplateURL>


### PR DESCRIPTION
Will fix the misleading (but accurate) fatal template error of Multiple Overviews found in CA.  Also removes the anchor link (but leaves the URL) as all HTML winds up getting removed in 6.10 due to security issues.